### PR TITLE
V2签名支持

### DIFF
--- a/plugin/src/main/groovy/com/mcxiaoke/packer/ng/ArchiveAllApkTask.groovy
+++ b/plugin/src/main/groovy/com/mcxiaoke/packer/ng/ArchiveAllApkTask.groovy
@@ -114,6 +114,11 @@ class ArchiveAllApkTask extends DefaultTask {
             }
         }
         logger.info(":${project.name}:${name} markets:[${theMarkets.join(', ')}]")
+        def signingConfig = getSigningConfig()
+        def keyAlias = signingConfig.keyAlias
+        def keyPassword = signingConfig.keyPassword
+        def storePassword = signingConfig.storePassword
+        def storeFile = signingConfig.storeFile
         for (String market : theMarkets) {
             File tempFile = new File(outputDir, market + ".tmp")
             copyTo(originalFile, tempFile)
@@ -124,11 +129,6 @@ class ArchiveAllApkTask extends DefaultTask {
                 if (PackerNg.Helper.verifyMarket(tempFile, market)) {
                     println(":${project.name}:${name} Generating apk for ${market}")
                     tempFile.renameTo(finalFile)
-                    def signingConfig = getSigningConfig()
-                    def keyAlias = signingConfig.keyAlias
-                    def keyPassword = signingConfig.keyPassword
-                    def storePassword = signingConfig.storePassword
-                    def storeFile = signingConfig.storeFile
                     if (signingConfig.v2SigningEnabled && new File(signfile).exists()) {
                         logger.info("java -jar ${signfile} sign --ks ${project.projectDir}/android.keystore --ks-key-alias android --ks-pass pass:android --key-pass pass:android --out ${finalFile} ${finalFile}")
                         Runtime.getRuntime().exec("java -jar ${signfile} sign --ks ${storeFile} --ks-key-alias ${keyAlias} --ks-pass pass:${storePassword} --key-pass pass:${keyPassword} --out ${finalFile} ${finalFile}")


### PR DESCRIPTION
添加对v2签名的支持。
换个思路来实现v2的支持就会比较容易。
v2签名是对整个apk文件进行签名，那么如果我们在修改了apk文件（添加zip comment后）之后再对修改之后的文件重新进行签名就行了。
这里只是在原有的基础上添加了使用sdk内自带的v2签名工具进行签名的代码。

注释了v2签名的条件验证，现v2签名开关用来做是否进行v2签名的配置，与原生意义相同。
